### PR TITLE
Fix queue counter increment in producer

### DIFF
--- a/src/main/java/com/example/producerconsumer/QueueProducerImpl.java
+++ b/src/main/java/com/example/producerconsumer/QueueProducerImpl.java
@@ -47,7 +47,9 @@ public class QueueProducerImpl implements QueueProducer<String> {
 
                 System.out.println("Producer " + name + ": " + (isAddedToQueue ? "adds " + stringExpression + " to queue" : "DIDN'T manage to add"));
 
-                pcJobContext.getCounter().incrementAndGet();
+                if (isAddedToQueue) {
+                    pcJobContext.getCounter().incrementAndGet();
+                }
             } else if (stringExpression.equals(MathGeneratorService.POISON_PILL)) {
                 isAddedToQueue = pcJobContext.getQueue().offer(stringExpression);
             }


### PR DESCRIPTION
## Summary
- increment the queue counter only when an item is successfully added to the queue

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68679bf8d5208328b351833af26b66b7