### PR TITLE
Fix grammar in validation messages

### DIFF
--- a/src/main/java/com/example/producerconsumer/model/PCJobContext.java
+++ b/src/main/java/com/example/producerconsumer/model/PCJobContext.java
@@ -29,7 +29,7 @@ public class PCJobContext<T> {
     @Builder
     public PCJobContext(@NonNull BlockingQueue<T> queue, @NonNull AtomicInteger counter, @NonNull AtomicBoolean waitForEmptyingHalfOfTheQueue, @NonNull int queueCapacity, @NonNull int sleepTimeConsumer, @NonNull int sleepTimeProducer) {
         if (queueCapacity < 1) {
-            throw new IllegalArgumentException("Shared queue queueCapacity must be greater then 0.");
+            throw new IllegalArgumentException("Shared queue queueCapacity must be greater than 0.");
         }
 
         if (sleepTimeConsumer < 0 || sleepTimeProducer < 0) {

--- a/src/main/java/com/example/producerconsumer/services/ProducersConsumersService.java
+++ b/src/main/java/com/example/producerconsumer/services/ProducersConsumersService.java
@@ -70,13 +70,13 @@ public class ProducersConsumersService {
 
     private void validateParameters(int numberOfProducers, int numberOfConsumers) {
         if (numberOfConsumers < 1 || numberOfProducers < 1) {
-            throw new IllegalArgumentException("Number of producers and consumers must be greater then 0.");
+            throw new IllegalArgumentException("Number of producers and consumers must be greater than 0.");
         }
         // because we implemented POISON_PILL(stopping of all consumers when producers finish theirs work)
         // there is a case when if numberOfProducers > numberOfConsumers the consumers stop consuming the tasks,
         // see how pillsPerProducer and pillsToBeAddedToLastProducer are used
         if (numberOfConsumers < numberOfProducers) {
-            throw new IllegalArgumentException("Number of consumers must be greater or equal then producers.");
+            throw new IllegalArgumentException("Number of consumers must be greater or equal than producers.");
         }
     }
 


### PR DESCRIPTION
## Summary
- fix PCJobContext queue capacity validation message
- fix ProducersConsumersService validation messages

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68679d56bf848328beaefd706a526b7b