### PR TITLE
Improve shutdown handling for producers and consumers

### DIFF
--- a/src/main/java/com/example/producerconsumer/services/ProducersConsumersService.java
+++ b/src/main/java/com/example/producerconsumer/services/ProducersConsumersService.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Class that creates List of Producers and List of Consumers that that are linked with each other by the same BlockingQueue.
@@ -94,6 +95,17 @@ public class ProducersConsumersService {
             consumersThreadPool.invokeAll(callable);
         } catch (InterruptedException e) {
             e.printStackTrace();
+            Thread.currentThread().interrupt();
+        } finally {
+            producersThreadPool.shutdown();
+            consumersThreadPool.shutdown();
+            try {
+                producersThreadPool.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
+                consumersThreadPool.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+                Thread.currentThread().interrupt();
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- cleanly terminate producer and consumer thread pools

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68679d4bf2f88328bcf76e67e28e4a4c