### PR TITLE
Add queue visualization using progress bar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,11 @@
             <version>1.0.2</version>
         </dependency>
         <dependency>
+            <groupId>me.tongfei</groupId>
+            <artifactId>progressbar</artifactId>
+            <version>0.10.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <version>3.27.3</version>

--- a/src/main/java/com/example/producerconsumer/QueueConsumerImpl.java
+++ b/src/main/java/com/example/producerconsumer/QueueConsumerImpl.java
@@ -4,6 +4,7 @@ import com.example.producerconsumer.interfaces.QueueConsumer;
 import com.example.producerconsumer.interfaces.QueueElementProcessor;
 import com.example.producerconsumer.model.PCJobContext;
 import com.example.producerconsumer.services.MathGeneratorService;
+import com.example.producerconsumer.QueueVisualizer;
 
 import java.util.List;
 
@@ -16,12 +17,14 @@ public class QueueConsumerImpl implements QueueConsumer<String> {
     final private QueueElementProcessor<String> consumerService;
     final private PCJobContext<String> pcJobContext;
     final private String name;
+    final private QueueVisualizer queueVisualizer;
 
-    public QueueConsumerImpl(String name, List<String> messagesOutputList, QueueElementProcessor<String> consumerService, PCJobContext<String> pcJobContext) {
+    public QueueConsumerImpl(String name, List<String> messagesOutputList, QueueElementProcessor<String> consumerService, PCJobContext<String> pcJobContext, QueueVisualizer queueVisualizer) {
         this.name = name;
         this.messagesOutputList = messagesOutputList;
         this.consumerService = consumerService;
         this.pcJobContext = pcJobContext;
+        this.queueVisualizer = queueVisualizer;
     }
     
     @Override
@@ -57,6 +60,7 @@ public class QueueConsumerImpl implements QueueConsumer<String> {
             }
             // decrement only if > 1
             int checkIfProducersCanStartAddingToQueue = pcJobContext.getCounter().updateAndGet(i -> i > 0 ? i - 1 : i);
+            queueVisualizer.update(checkIfProducersCanStartAddingToQueue);
 
             // stop blocking Producers if queue is half empty
             if (pcJobContext.getWaitForEmptyingHalfOfTheQueue().get() && checkIfProducersCanStartAddingToQueue < (pcJobContext.getQueueCapacity() / 2)) {

--- a/src/main/java/com/example/producerconsumer/QueueProducerImpl.java
+++ b/src/main/java/com/example/producerconsumer/QueueProducerImpl.java
@@ -3,6 +3,7 @@ package com.example.producerconsumer;
 import com.example.producerconsumer.interfaces.QueueProducer;
 import com.example.producerconsumer.model.PCJobContext;
 import com.example.producerconsumer.services.MathGeneratorService;
+import com.example.producerconsumer.QueueVisualizer;
 
 import java.util.stream.Stream;
 
@@ -13,11 +14,13 @@ public class QueueProducerImpl implements QueueProducer<String> {
     final private PCJobContext<String> pcJobContext;
     final private Stream<String> exprStream;
     final private String name;
+    final private QueueVisualizer queueVisualizer;
 
-    public QueueProducerImpl(String name, PCJobContext<String> pcJobContext, Stream<String> exprStream) {
+    public QueueProducerImpl(String name, PCJobContext<String> pcJobContext, Stream<String> exprStream, QueueVisualizer queueVisualizer) {
         this.name = name;
         this.pcJobContext = pcJobContext;
         this.exprStream = exprStream;
+        this.queueVisualizer = queueVisualizer;
     }
 
     @Override
@@ -50,7 +53,8 @@ public class QueueProducerImpl implements QueueProducer<String> {
                 System.out.println("Producer " + name + ": " + (isAddedToQueue ? "adds " + stringExpression + " to queue" : "DIDN'T manage to add"));
 
                 if (isAddedToQueue) {
-                    pcJobContext.getCounter().incrementAndGet();
+                    int newSize = pcJobContext.getCounter().incrementAndGet();
+                    queueVisualizer.update(newSize);
                 }
             } else if (stringExpression.equals(MathGeneratorService.POISON_PILL)) {
                 isAddedToQueue = pcJobContext.getQueue().offer(stringExpression);

--- a/src/main/java/com/example/producerconsumer/QueueVisualizer.java
+++ b/src/main/java/com/example/producerconsumer/QueueVisualizer.java
@@ -1,0 +1,24 @@
+package com.example.producerconsumer;
+
+import me.tongfei.progressbar.ProgressBar;
+
+/**
+ * Simple helper that visualizes the current queue size using a progress bar.
+ */
+public class QueueVisualizer {
+
+    private final ProgressBar progressBar;
+
+    public QueueVisualizer(int capacity) {
+        this.progressBar = new ProgressBar("Queue", capacity);
+        this.progressBar.stepTo(0);
+    }
+
+    public synchronized void update(int currentSize) {
+        progressBar.stepTo(currentSize);
+    }
+
+    public synchronized void close() {
+        progressBar.close();
+    }
+}

--- a/src/main/java/com/example/producerconsumer/config/PCJobContextConfig.java
+++ b/src/main/java/com/example/producerconsumer/config/PCJobContextConfig.java
@@ -1,6 +1,7 @@
 package com.example.producerconsumer.config;
 
 import com.example.producerconsumer.model.PCJobContext;
+import com.example.producerconsumer.QueueVisualizer;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Bean;
@@ -44,5 +45,11 @@ public class PCJobContextConfig {
                 .sleepTimeProducer(sleepTimeProducers)
                 .sleepTimeConsumer(sleepTimeConsumers)
                 .build();
+    }
+
+    @Bean
+    @Scope(value = ConfigurableBeanFactory.SCOPE_SINGLETON)
+    public QueueVisualizer getQueueVisualizer() {
+        return new QueueVisualizer(queueCapacity);
     }
 }

--- a/src/test/java/com/example/producerconsumer/QueueConsumerImplTest.java
+++ b/src/test/java/com/example/producerconsumer/QueueConsumerImplTest.java
@@ -11,11 +11,14 @@ import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import com.example.producerconsumer.QueueVisualizer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 public class QueueConsumerImplTest {
 
     final ConsumerService  consumerService = new ConsumerService();
+
+    QueueVisualizer queueVisualizer;
 
     PCJobContext<String> pcJobContext;
     @Before
@@ -28,6 +31,7 @@ public class QueueConsumerImplTest {
                 .sleepTimeConsumer(0)
                 .sleepTimeProducer(0)
                 .build();
+        queueVisualizer = new QueueVisualizer(1);
     }
 
     @Test
@@ -35,7 +39,7 @@ public class QueueConsumerImplTest {
         //given
         List<String> messagesOutputList = new ArrayList<>();
         //when
-        new QueueConsumerImpl("C1", messagesOutputList, consumerService, pcJobContext).consume(MathGeneratorService.POISON_PILL);
+        new QueueConsumerImpl("C1", messagesOutputList, consumerService, pcJobContext, queueVisualizer).consume(MathGeneratorService.POISON_PILL);
         //then
         assertThat(messagesOutputList).containsOnly("Poison pill swallowed by: C1");
     }
@@ -45,7 +49,7 @@ public class QueueConsumerImplTest {
         //given
         List<String> messagesOutputList = new ArrayList<>();
         //when
-        new QueueConsumerImpl("C1", messagesOutputList, consumerService, pcJobContext).consume("2+2");
+        new QueueConsumerImpl("C1", messagesOutputList, consumerService, pcJobContext, queueVisualizer).consume("2+2");
         //then
         assertThat(messagesOutputList).containsOnly("Consumer C1: 2+2 = 4");
     }
@@ -62,7 +66,7 @@ public class QueueConsumerImplTest {
                 .queueCapacity(2)
                 .sleepTimeConsumer(0)
                 .sleepTimeProducer(0)
-                .build()).consume("2+2");
+                .build(), new QueueVisualizer(2)).consume("2+2");
         //then
         assertThat(messagesOutputList).containsOnly("Consumer C1: 2+2 = 4","Start blocking Producers");
     }
@@ -79,7 +83,7 @@ public class QueueConsumerImplTest {
                 .queueCapacity(2)
                 .sleepTimeConsumer(0)
                 .sleepTimeProducer(0)
-                .build()).consume("2+2");
+                .build(), new QueueVisualizer(2)).consume("2+2");
         //then
         assertThat(messagesOutputList).containsOnly("Consumer C1: 2+2 = 4", "Stop blocking Producers");
     }
@@ -89,6 +93,6 @@ public class QueueConsumerImplTest {
         //given
         List<String> messagesOutputList = new ArrayList<>();
         //when
-        new QueueConsumerImpl("C1", messagesOutputList, consumerService, pcJobContext).consume("2/0");
+        new QueueConsumerImpl("C1", messagesOutputList, consumerService, pcJobContext, queueVisualizer).consume("2/0");
     }
 }

--- a/src/test/java/com/example/producerconsumer/services/ProducersConsumersServiceTests.java
+++ b/src/test/java/com/example/producerconsumer/services/ProducersConsumersServiceTests.java
@@ -3,6 +3,7 @@ package com.example.producerconsumer.services;
 import com.example.producerconsumer.interfaces.QueueConsumer;
 import com.example.producerconsumer.interfaces.QueueProducer;
 import com.example.producerconsumer.model.PCJobContext;
+import com.example.producerconsumer.QueueVisualizer;
 import org.javatuples.Triplet;
 import org.junit.After;
 import org.junit.Before;
@@ -34,7 +35,7 @@ public class ProducersConsumersServiceTests {
                 .queueCapacity(10)
                 .sleepTimeProducer(0)
                 .sleepTimeConsumer(0)
-                .build());
+                .build(), new QueueVisualizer(10));
     }
 
     @After
@@ -67,7 +68,7 @@ public class ProducersConsumersServiceTests {
                 .sleepTimeProducer(10)
                 .sleepTimeConsumer(20)
                 .build();
-        ProducersConsumersService producersConsumersService = new ProducersConsumersService(new ConsumerService(), pcJobContextObjectProvider);
+        ProducersConsumersService producersConsumersService = new ProducersConsumersService(new ConsumerService(), pcJobContextObjectProvider, new QueueVisualizer(10));
 
         Triplet<List<QueueProducer<String>>, List<QueueConsumer<String>>, List<String>> producersAndConsumers = producersConsumersService.prepareProducersAndConsumers(numberOfProducers, numberOfConsumers, new MathGeneratorService(5, 100, 10));
 
@@ -120,7 +121,7 @@ public class ProducersConsumersServiceTests {
                 .sleepTimeProducer(10)
                 .sleepTimeConsumer(100)
                 .build();
-        ProducersConsumersService producersConsumersService = new ProducersConsumersService(new ConsumerService(), pcJobContextObjectProvider);
+        ProducersConsumersService producersConsumersService = new ProducersConsumersService(new ConsumerService(), pcJobContextObjectProvider, new QueueVisualizer(10));
 
         Triplet<List<QueueProducer<String>>, List<QueueConsumer<String>>, List<String>> producersAndConsumers = producersConsumersService.prepareProducersAndConsumers(numberOfProducers, numberOfConsumers, new MathGeneratorService(5, 100, 10));
         //when invoke producers
@@ -168,7 +169,7 @@ public class ProducersConsumersServiceTests {
                 .sleepTimeProducer(100)
                 .sleepTimeConsumer(10)
                 .build();
-        ProducersConsumersService producersConsumersService = new ProducersConsumersService(new ConsumerService(), pcJobContextObjectProvider);
+        ProducersConsumersService producersConsumersService = new ProducersConsumersService(new ConsumerService(), pcJobContextObjectProvider, new QueueVisualizer(10));
 
 
         Triplet<List<QueueProducer<String>>, List<QueueConsumer<String>>, List<String>> producersAndConsumers = producersConsumersService.prepareProducersAndConsumers(numberOfProducers, numberOfConsumers, new MathGeneratorService(1, 1, 1));


### PR DESCRIPTION
## Summary
- add `QueueVisualizer` helper using `progressbar` library
- update config to provide a `QueueVisualizer` bean
- inject visualizer into producers, consumers, and service
- update tests for the new constructor arguments
- add progressbar dependency

## Testing
- `./mvnw -q -DskipTests package` *(fails: Network is unreachable)*
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6867a7e431388328a2defab2f3c5cd09